### PR TITLE
Add upload_media, upload_attachment, and media_ids to create_campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,13 @@ client.send_campaign(cid)
 - `campaign_recipients(campaign_id, subscription_status=None) -> list[Subscriber]` — convenience: reads the campaign's target lists and resolves their subscribers. Pass `subscription_status="confirmed"` (or other valid value) to filter; `None` means "everyone on the lists."
 - `get_rendered_html(campaign_id) -> str` — Listmonk's server-rendered HTML (template applied) — what a recipient sees in their inbox
 - `build_send_manifest(campaign_id) -> SendManifest` — structured pre-send snapshot (name, subject, status, target lists, recipients) for custom review/display. Call `manifest.format()` for a printable multi-line string.
+- `fetch_all_lists(*, tag=None) -> list[dict]` — all lists (paginated), optionally filtered by `tag`. Returns raw Listmonk list records.
 
 **Write / action**
-- `create_campaign(*, name, subject, body, list_ids=None, template_id=8, content_type="html") -> int` — POSTs a new draft, returns new campaign id. `template_id=8` is the OCHA Listmonk's canonical campaign template; override if you're pointing at a different Listmonk instance.
+- `create_campaign(*, name, subject, body, list_ids=None, template_id=8, content_type="html", media_ids=None) -> int` — POSTs a new draft, returns new campaign id. `template_id=8` is the OCHA Listmonk's canonical campaign template; override if you're pointing at a different Listmonk instance. `media_ids` attaches uploaded media (from `upload_attachment`) to the email.
+- `create_list(*, name, list_type="public", optin="single", tags=None) -> int` — creates a list, returns new list id. `list_type` is `"public"`/`"private"`; `optin` is `"single"`/`"double"`.
+- `upload_media(data, filename="image.png") -> str` — uploads bytes to the media library, returns the hosted URL for use in inline `<img src="...">` tags (hosting avoids the base64 bloat that makes Gmail clip emails over ~102 KB). MIME type is guessed from `filename`.
+- `upload_attachment(data, filename) -> int` — uploads bytes and returns the integer media id for the `media_ids` arg of `create_campaign` (attaches the file rather than inlining it).
 - `send_campaign(campaign_id, *, skip_confirmation=False, ask=input) -> None` — transitions campaign to `running` (the actual email-triggering call). Default prompts for confirmation; refuses status `"finished"` in both modes (re-sending would duplicate emails).
 - `preview_in_browser(campaign_id) -> Path` — fetches rendered HTML, writes to a temp file, calls `webbrowser.open` on it
 

--- a/src/ocha_relay/listmonk.py
+++ b/src/ocha_relay/listmonk.py
@@ -173,6 +173,7 @@ class ListmonkClient:
         list_ids: list[int] | None = None,
         template_id: int = DEFAULT_CAMPAIGN_TEMPLATE_ID,
         content_type: str = "html",
+        media_ids: list[int] | None = None,
     ) -> int:
         """Create a campaign in draft state. Returns the new campaign ID.
 
@@ -184,6 +185,10 @@ class ListmonkClient:
         are pointing this client at a different Listmonk, pass the
         ``template_id`` of that instance's campaign template — using ``8``
         blindly will either 400 or wrap your body in the wrong template.
+
+        ``media_ids`` is a list of Listmonk media IDs to attach to the
+        campaign email. Upload files first with :meth:`upload_attachment`
+        to obtain their IDs.
         """
         payload: dict[str, Any] = {
             "name": name,
@@ -193,6 +198,7 @@ class ListmonkClient:
             "type": "regular",
             "content_type": content_type,
             "body": body,
+            "media": media_ids or [],
         }
         r = requests.post(
             f"{self.base_url}/campaigns",
@@ -233,6 +239,33 @@ class ListmonkClient:
         r.raise_for_status()
         url: str = r.json()["data"]["url"]
         return url
+
+    def upload_attachment(self, data: bytes, filename: str) -> int:
+        """Upload a file to Listmonk and return its media ID for use as an attachment.
+
+        Unlike :meth:`upload_media` (which returns a URL for inline ``<img>``
+        tags), this returns the integer media ID needed in the ``media_ids``
+        list of :meth:`create_campaign` to attach the file to the email.
+
+        Example::
+
+            mid = client.upload_attachment(csv_bytes, "exposure.csv")
+            cid = client.create_campaign(..., media_ids=[mid])
+        """
+        import mimetypes
+
+        mime_type, _ = mimetypes.guess_type(filename)
+        if mime_type is None:
+            mime_type = "application/octet-stream"
+        r = requests.post(
+            f"{self.base_url}/media",
+            auth=self._auth,
+            files={"file": (filename, data, mime_type)},
+            timeout=self.timeout,
+        )
+        r.raise_for_status()
+        media_id: int = r.json()["data"]["id"]
+        return media_id
 
     def send_campaign(
         self,

--- a/src/ocha_relay/listmonk.py
+++ b/src/ocha_relay/listmonk.py
@@ -204,6 +204,36 @@ class ListmonkClient:
         campaign_id: int = r.json()["data"]["id"]
         return campaign_id
 
+    def upload_media(self, data: bytes, filename: str = "image.png") -> str:
+        """Upload a file to the Listmonk media library. Returns the hosted URL.
+
+        ``data`` is the raw file bytes. ``filename`` sets the filename sent to
+        Listmonk; the extension determines the MIME type (png, jpg, gif, pdf
+        are all accepted by Listmonk). Use the returned URL in campaign HTML
+        ``<img src="...">`` tags so images are hosted rather than inlined as
+        data URIs — inline base64 inflates the email body and causes Gmail to
+        clip messages over ~102 KB.
+
+        Example::
+
+            url = client.upload_media(png_bytes, "chart.png")
+            html = f'<img src="{url}">'
+        """
+        import mimetypes
+
+        mime_type, _ = mimetypes.guess_type(filename)
+        if mime_type is None:
+            mime_type = "application/octet-stream"
+        r = requests.post(
+            f"{self.base_url}/media",
+            auth=self._auth,
+            files={"file": (filename, data, mime_type)},
+            timeout=self.timeout,
+        )
+        r.raise_for_status()
+        url: str = r.json()["data"]["url"]
+        return url
+
     def send_campaign(
         self,
         campaign_id: int,

--- a/src/ocha_relay/listmonk.py
+++ b/src/ocha_relay/listmonk.py
@@ -440,6 +440,52 @@ class ListmonkClient:
             page += 1
         return subscribers
 
+    def create_list(
+        self,
+        *,
+        name: str,
+        list_type: str = "public",
+        optin: str = "single",
+        tags: list[str] | None = None,
+    ) -> int:
+        """Create a list. Returns the new list ID."""
+        payload: dict[str, Any] = {
+            "name": name,
+            "type": list_type,
+            "optin": optin,
+            "tags": tags or [],
+        }
+        r = requests.post(
+            f"{self.base_url}/lists",
+            auth=self._auth,
+            json=payload,
+            timeout=self.timeout,
+        )
+        r.raise_for_status()
+        return int(r.json()["data"]["id"])
+
+    def fetch_all_lists(self, *, tag: str | None = None) -> list[dict[str, Any]]:
+        """Fetch all lists (paginated). Optionally filter by tag."""
+        params: list[tuple[str, Any]] = [("per_page", 100)]
+        if tag:
+            params.append(("tag", tag))
+        results: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            r = requests.get(
+                f"{self.base_url}/lists",
+                auth=self._auth,
+                params=[*params, ("page", page)],
+                timeout=self.timeout,
+            )
+            r.raise_for_status()
+            data = r.json()["data"]
+            results.extend(data["results"])
+            if page * data["per_page"] >= data["total"]:
+                break
+            page += 1
+        return results
+
     def campaign_recipients(
         self,
         campaign_id: int,

--- a/src/ocha_relay/listmonk.py
+++ b/src/ocha_relay/listmonk.py
@@ -5,6 +5,7 @@ Listmonk API reference: https://listmonk.app/docs/apis/apis/
 
 from __future__ import annotations
 
+import mimetypes
 import os
 import tempfile
 import webbrowser
@@ -225,19 +226,7 @@ class ListmonkClient:
             url = client.upload_media(png_bytes, "chart.png")
             html = f'<img src="{url}">'
         """
-        import mimetypes
-
-        mime_type, _ = mimetypes.guess_type(filename)
-        if mime_type is None:
-            mime_type = "application/octet-stream"
-        r = requests.post(
-            f"{self.base_url}/media",
-            auth=self._auth,
-            files={"file": (filename, data, mime_type)},
-            timeout=self.timeout,
-        )
-        r.raise_for_status()
-        url: str = r.json()["data"]["url"]
+        url: str = self._upload_to_media(data, filename)["url"]
         return url
 
     def upload_attachment(self, data: bytes, filename: str) -> int:
@@ -252,11 +241,18 @@ class ListmonkClient:
             mid = client.upload_attachment(csv_bytes, "exposure.csv")
             cid = client.create_campaign(..., media_ids=[mid])
         """
-        import mimetypes
+        media_id: int = self._upload_to_media(data, filename)["id"]
+        return media_id
 
-        mime_type, _ = mimetypes.guess_type(filename)
-        if mime_type is None:
-            mime_type = "application/octet-stream"
+    def _upload_to_media(self, data: bytes, filename: str) -> dict[str, Any]:
+        """POST a file to ``/media`` and return the ``data`` dict.
+
+        Shared by :meth:`upload_media` and :meth:`upload_attachment`, which
+        differ only in which field of the response they read (``url`` vs
+        ``id``). The MIME type is guessed from ``filename``, falling back to
+        ``application/octet-stream`` for unknown extensions.
+        """
+        mime_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
         r = requests.post(
             f"{self.base_url}/media",
             auth=self._auth,
@@ -264,8 +260,8 @@ class ListmonkClient:
             timeout=self.timeout,
         )
         r.raise_for_status()
-        media_id: int = r.json()["data"]["id"]
-        return media_id
+        data_dict: dict[str, Any] = r.json()["data"]
+        return data_dict
 
     def send_campaign(
         self,
@@ -448,7 +444,15 @@ class ListmonkClient:
         optin: str = "single",
         tags: list[str] | None = None,
     ) -> int:
-        """Create a list. Returns the new list ID."""
+        """Create a list. Returns the new list ID.
+
+        ``list_type`` is the list's visibility: ``"public"`` (the default;
+        appears on the public subscription page) or ``"private"``.
+
+        ``optin`` is the confirmation mode: ``"single"`` (the default;
+        subscribers are added directly) or ``"double"`` (subscribers must
+        click a confirmation link before they count as ``confirmed``).
+        """
         payload: dict[str, Any] = {
             "name": name,
             "type": list_type,
@@ -481,6 +485,11 @@ class ListmonkClient:
             r.raise_for_status()
             data = r.json()["data"]
             results.extend(data["results"])
+            # Defensive: a malformed per_page=0 response would wedge the
+            # pagination check (0 * anything is never >= total). Bail
+            # rather than loop forever. Mirrors list_subscribers.
+            if data["per_page"] == 0:
+                break
             if page * data["per_page"] >= data["total"]:
                 break
             page += 1

--- a/tests/test_listmonk.py
+++ b/tests/test_listmonk.py
@@ -632,3 +632,254 @@ def test_preview_in_browser_writes_html_and_opens_default_browser(
     # Test-side cleanup — library deliberately leaves the temp file so
     # the browser has time to load it.
     path.unlink()
+
+
+# ---------- create_campaign media payload ----------
+
+
+def test_create_campaign_emits_media_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"data": {"id": 1}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    _client().create_campaign(name="n", subject="s", body="b", media_ids=[7, 8])
+
+    assert captured["json"]["media"] == [7, 8]
+
+
+def test_create_campaign_defaults_empty_media_when_none_passed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"data": {"id": 1}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    _client().create_campaign(name="n", subject="s", body="b")
+
+    assert captured["json"]["media"] == []
+
+
+# ---------- upload_media / upload_attachment ----------
+
+
+def test_upload_media_posts_multipart_and_returns_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["url"] = url
+        captured["auth"] = kwargs["auth"]
+        captured["files"] = kwargs["files"]
+        return _FakeResponse({"data": {"id": 12, "url": "https://cdn.x/chart.png"}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    url = _client().upload_media(b"\x89PNG...", "chart.png")
+
+    assert url == "https://cdn.x/chart.png"
+    assert captured["url"] == "https://listmonk.example.org/api/media"
+    assert captured["auth"] == ("u", "p")
+    # Multipart payload: ("file", (filename, data, mime_type)).
+    filename, data, mime_type = captured["files"]["file"]
+    assert filename == "chart.png"
+    assert data == b"\x89PNG..."
+    assert mime_type == "image/png"
+
+
+def test_upload_media_defaults_filename_to_image_png(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["files"] = kwargs["files"]
+        return _FakeResponse({"data": {"id": 1, "url": "https://cdn.x/image.png"}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    _client().upload_media(b"data")
+
+    filename, _data, mime_type = captured["files"]["file"]
+    assert filename == "image.png"
+    assert mime_type == "image/png"
+
+
+def test_upload_media_falls_back_to_octet_stream_for_unknown_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["files"] = kwargs["files"]
+        return _FakeResponse({"data": {"id": 1, "url": "https://cdn.x/f"}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    _client().upload_media(b"data", "mystery.unknownext")
+
+    _filename, _data, mime_type = captured["files"]["file"]
+    assert mime_type == "application/octet-stream"
+
+
+def test_upload_attachment_returns_media_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["url"] = url
+        captured["files"] = kwargs["files"]
+        return _FakeResponse({"data": {"id": 55, "url": "https://cdn.x/exposure.csv"}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    media_id = _client().upload_attachment(b"a,b,c", "exposure.csv")
+
+    assert media_id == 55
+    assert captured["url"] == "https://listmonk.example.org/api/media"
+    filename, data, mime_type = captured["files"]["file"]
+    assert filename == "exposure.csv"
+    assert data == b"a,b,c"
+    assert mime_type == "text/csv"
+
+
+def test_upload_attachment_raises_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        return _FakeResponse({"data": {}}, status_code=500)
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    with pytest.raises(requests.HTTPError):
+        _client().upload_attachment(b"data", "f.csv")
+
+
+# ---------- create_list ----------
+
+
+def test_create_list_posts_payload_and_returns_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["url"] = url
+        captured["json"] = kwargs["json"]
+        captured["auth"] = kwargs["auth"]
+        return _FakeResponse({"data": {"id": 21}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    result = _client().create_list(name="DS alerts", tags=["ds", "alerts"])
+
+    assert result == 21
+    assert captured["url"] == "https://listmonk.example.org/api/lists"
+    assert captured["auth"] == ("u", "p")
+    payload = captured["json"]
+    assert payload["name"] == "DS alerts"
+    assert payload["type"] == "public"  # default
+    assert payload["optin"] == "single"  # default
+    assert payload["tags"] == ["ds", "alerts"]
+
+
+def test_create_list_defaults_empty_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["json"] = kwargs["json"]
+        return _FakeResponse({"data": {"id": 1}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    _client().create_list(name="n")
+
+    assert captured["json"]["tags"] == []
+
+
+# ---------- fetch_all_lists ----------
+
+
+def _lists_page(
+    results: list[dict[str, Any]], total: int, page: int, per_page: int
+) -> dict[str, Any]:
+    return {
+        "data": {"results": results, "total": total, "page": page, "per_page": per_page}
+    }
+
+
+def test_fetch_all_lists_single_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["url"] = url
+        captured["params"] = kwargs["params"]
+        rows = [{"id": 1, "name": "L1"}, {"id": 2, "name": "L2"}]
+        return _FakeResponse(_lists_page(rows, total=2, page=1, per_page=100))
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = _client().fetch_all_lists()
+
+    assert [lst["id"] for lst in result] == [1, 2]
+    assert captured["url"] == "https://listmonk.example.org/api/lists"
+    assert ("per_page", 100) in captured["params"]
+
+
+def test_fetch_all_lists_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        page = dict(kwargs["params"])["page"]
+        if page == 1:
+            return _FakeResponse(
+                _lists_page([{"id": 1}, {"id": 2}], total=3, page=1, per_page=2)
+            )
+        return _FakeResponse(_lists_page([{"id": 3}], total=3, page=2, per_page=2))
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = _client().fetch_all_lists()
+
+    assert [lst["id"] for lst in result] == [1, 2, 3]
+
+
+def test_fetch_all_lists_forwards_tag_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        captured["params"] = kwargs["params"]
+        return _FakeResponse(_lists_page([], total=0, page=1, per_page=100))
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    _client().fetch_all_lists(tag="alerts")
+
+    assert ("tag", "alerts") in captured["params"]
+
+
+def test_fetch_all_lists_bails_on_malformed_per_page_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per_page=0 response must not wedge the pagination loop forever."""
+    calls: list[int] = []
+
+    def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
+        calls.append(dict(kwargs["params"])["page"])
+        return _FakeResponse(_lists_page([{"id": 1}], total=5, page=1, per_page=0))
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = _client().fetch_all_lists()
+
+    assert [lst["id"] for lst in result] == [1]
+    assert calls == [1]  # bailed after the first page instead of looping


### PR DESCRIPTION
## Summary

- `upload_media(data, filename) -> str`: uploads bytes to the Listmonk media library and returns the hosted URL. Use for inline `<img src="...">` tags in campaign HTML — avoids data URIs which inflate the body and cause Gmail to clip messages over ~102 KB.
- `upload_attachment(data, filename) -> int`: uploads bytes and returns the integer media ID. Use for email file attachments (e.g. CSV files).
- `create_campaign` gains a `media_ids: list[int]` parameter mapping to the Listmonk API's `"media"` field, so attachments can be associated with a campaign at creation time.

## Motivation

Pipelines that generate charts or data exports need a clean way to (1) host images for Gmail-safe embedding and (2) attach files like CSVs to campaigns. Both operations go through the same `/api/media` endpoint but return different things — URL for inline use, ID for attachment use.

## Test plan

- [ ] `upload_media` returns a valid `https://` URL; image accessible at that URL
- [ ] `upload_attachment` returns an integer media ID
- [ ] Campaign created with `media_ids=[id]` has the file attached in Listmonk and the attachment appears in the sent email

🤖 Generated with [Claude Code](https://claude.ai/claude-code)