### PR TITLE
Release v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Until this package is published on PyPI, install directly from Git in any uv-man
 
 ```bash
 # Pin to a release tag (recommended — immutable ref):
-uv add "ocha-relay @ git+https://github.com/OCHA-DAP/ocha-relay.git@v0.2.0"
+uv add "ocha-relay @ git+https://github.com/OCHA-DAP/ocha-relay.git@v0.3.0"
 
 # Pin to main (moves with the default branch):
 uv add "ocha-relay @ git+https://github.com/OCHA-DAP/ocha-relay.git@main"
@@ -35,7 +35,7 @@ This lands in the consumer's `pyproject.toml` as:
 dependencies = ["ocha-relay"]
 
 [tool.uv.sources]
-ocha-relay = { git = "https://github.com/OCHA-DAP/ocha-relay.git", rev = "v0.2.0" }
+ocha-relay = { git = "https://github.com/OCHA-DAP/ocha-relay.git", rev = "v0.3.0" }
 ```
 
 (Older uv versions inlined the Git URL directly into `dependencies` using the `"ocha-relay @ git+https://..."` form. Either shape installs the same package; current uv writes the `[tool.uv.sources]` layout above.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ocha-relay"
-version = "0.2.0"
+version = "0.3.0"
 description = "Internal utilities for the OCHA data science team's automated tools and communications."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts the `v0.3.0` release for the media-upload + list-management methods merged in #4.

- Bumps `pyproject.toml` version `0.2.0` → `0.3.0` (minor: new backward-compatible public methods — `upload_media`, `upload_attachment`, `create_list`, `fetch_all_lists`, and the `media_ids` parameter on `create_campaign`).
- Bumps the README install-example pins `v0.2.0` → `v0.3.0`.

After merge: tag `v0.3.0` and bump the downstream pins in `ds-storms-alerts` and `ds-storm-impact-harmonisation`.